### PR TITLE
Fix 404 errors on updates

### DIFF
--- a/dyndns/main.go
+++ b/dyndns/main.go
@@ -98,7 +98,7 @@ func main() {
 	updateRoute.GET("", h.UpdateIP)
 	nicRoute := e.Group("/nic")
 	nicRoute.Use(middleware.BasicAuth(h.AuthenticateUpdate))
-	updateRoute.GET("/update", h.UpdateIP)
+	nicRoute.GET("/update", h.UpdateIP)
 	v2Route := e.Group("/v2")
 	v2Route.Use(middleware.BasicAuth(h.AuthenticateUpdate))
 	v2Route.GET("/update", h.UpdateIP)


### PR DESCRIPTION
Before change you get these errors constantly on any host ip update:

{"time":"2022-05-09T19:03:38.40895553Z","id":"","remote_ip":"69.1.2.3","host":"ddns.domain.com","method":"GET","uri":"/nic/update?system=dyndns&hostname=test1.ddns.domain.com&myip=&wildcard=OFF&mx=NO&backmx=NO&offline=NO","user_agent":"Hikvision-dvrdvs-1.0.0","status":404,"error":"code=404, message=Not Found","latency":895808,"latency_human":"895.808µs","bytes_in":0,"bytes_out":24}
{"time":"2022-05-09T19:03:40.496361052Z","id":"","remote_ip":"69.3.2.1","host":"ddns.domain.com","method":"GET","uri":"/nic/update?system=dyndns&hostname=test2.ddns.domain.com&myip=&wildcard=OFF&mx=NO&backmx=NO&offline=NO","user_agent":"Hikvision-dvrdvs-1.0.0","status":404,"error":"code=404, message=Not Found","latency":796442,"latency_human":"796.442µs","bytes_in":0,"bytes_out":24}
{"time":"2022-05-09T19:03:45.375560893Z","id":"","remote_ip":"69.4.4.4","host":"ddns.domain.com","method":"GET","uri":"/nic/update?system=dyndns&hostname=test3.ddns.domain.com&myip=&wildcard=OFF&mx=NO&backmx=NO&offline=NO","user_agent":"Hikvision-dvrdvs-1.0.0","status":404,"error":"code=404, message=Not Found","latency":774547,"latency_human":"774.547µs","bytes_in":0,"bytes_out":24}

After change... hosts are updated... no issues.