### PR TITLE
Fix unending loop on wrong url input...

### DIFF
--- a/dyndns/main.go
+++ b/dyndns/main.go
@@ -59,7 +59,7 @@ func main() {
 	groupPublic := e.Group("/")
 	groupPublic.GET("*", func(c echo.Context) error {
 		//redirect to admin
-		return c.Redirect(301, "./admin/")
+		return c.Redirect(301, "/admin/")
 	})
 	groupAdmin := e.Group("/admin")
 	if authAdmin {


### PR DESCRIPTION
I noticed cases of unending (till browser stops it) loop involving the /admin url if there's an error in the url... e.g:
`ddns.url/admin/admin/admin/admin/admin/admin/admin/admin/admin/admin/admin/admin/admin/admin/...`

The problem was solved by removing the dot ( . ) before /admin/ on line 62. And doesn't seem to break anything else.