### PR TITLE
Fix form validation for IPv6 addresses

### DIFF
--- a/dyndns/model/host.go
+++ b/dyndns/model/host.go
@@ -11,7 +11,7 @@ type Host struct {
 	gorm.Model
 	Hostname   string    `gorm:"unique_index:idx_host_domain;not null" form:"hostname" validate:"required,hostname"`
 	Domain     string    `gorm:"unique_index:idx_host_domain;not null" form:"domain" validate:"required,hostname"`
-	Ip         string    `form:"ip" validate:"omitempty,ipv4"`
+	Ip         string    `form:"ip" validate:"omitempty,ipv4|ipv6"`
 	Ttl        int       `form:"ttl" validate:"required,min=20,max=86400"`
 	LastUpdate time.Time `form:"lastupdate"`
 	UserName   string    `gorm:"unique" form:"username" validate:"min=3"`


### PR DESCRIPTION
I tried to add a cname to a host that has an ipv6 address. This unfortunately fails, because the input validation tries to validate the ipv6 like an ipv4 address. Which of course makes sense.

I realized I could add ipv6 validation as well by just adding `|ipv6` in the host model definition. I hope this change is okay in your eyes. If so, please merge.